### PR TITLE
small ComputationManager-related refactors

### DIFF
--- a/src/Dataflow/ComputationManager.coffee
+++ b/src/Dataflow/ComputationManager.coffee
@@ -17,12 +17,15 @@ module.exports = class ComputationManager
   # never executed more than once. They will instead return their cached
   # value.
   run: (callback) ->
-    @isRunning = true
-    @counter++
-    try
-      return callback()
-    finally
-      @isRunning = false
+    if !@isRunning
+      @isRunning = true
+      @counter++
+      try
+        return callback()
+      finally
+        @isRunning = false
+    else
+      callback()
 
   # Takes a function and returns a memoized version.
   memoize: (fn) ->


### PR DESCRIPTION
Two small changes having to do with `ComputationManager`:
1. I found the "if `computationManager` isn't running, call myself recursively through `computationManager.run`" pattern to be confusing, so I put that behavior into `computationManager.run` itself. (This is a safe change unless there's a meaning to calling `computationManager.run` inside a callback passed to `computationManager.run`. In fact, I think it's safer than before?)
2. I switched to a more direct way of using `computationManager.memoize`.

(Heads up, I made both of these changes while working on a larger `Dataflow` refactor. That larger refactor may or may not make sense, but these seemed like good changes regardless.)
