### PR TITLE
add tests for Serializer (via cyclicDeepEqual)

### DIFF
--- a/src/Util/DeepEquality.coffee
+++ b/src/Util/DeepEquality.coffee
@@ -1,0 +1,133 @@
+_ = require "underscore"
+
+
+module.exports = DeepEquality = {}
+
+
+# Terminology: A "part" of a JS value is an object or array accessible from the
+# value through recursive property access (including array indexing). If we
+# like, we can also include prototype access as part of our recursive process,
+# though its best to ignore the boring prototype Object.prototype.
+
+
+# cyclicDeepEqual compares two Javascript values. It is comfortable with values
+# which have cyclic references between their parts. In this case, it will ensure
+# that the two values have isomorphic reference graphs.
+DeepEquality.cyclicDeepEqual = (a, b, opts) ->
+  # PLAN:
+  # Recursively check that each piece of a matches a corresponding piece of b.
+  # checkPartsEqual should do real work for each part aPart of a only once. This
+  # is possible with the following strategy:
+  #  * The first time checkPartsEqual is called on aPart, it checks that bPart
+  #    is a valid, unclaimed part of b, and then records the association between
+  #    aPart and bPart in an array called aPartToBPart. (This all happens before
+  #    any recursive calls.)
+  #  * If checkPartsEqual is called on aPart a second time, this is the result
+  #    of either a cyclic reference during the checking of aPart, or the
+  #    checking of some unrelated part of a. In either case, it suffices to
+  #    check that bPart matches the part of b previously recorded in
+  #    aPartToBPart.
+
+  opts ?= {}
+  _.defaults(opts, {
+    log: false,
+    checkPrototypes: true,
+  })
+
+  context = {
+    aParts: _extractParts(a, opts),
+    bParts: _extractParts(b, opts),
+    aPartToBPart: [],
+  }
+
+  if context.log then console.log 'aParts', context.aParts
+  if context.log then console.log 'bParts', context.bParts
+
+  return _checkValuesEqual(a, b, opts, context)
+
+
+_extractParts = (value, opts, toReturn = []) ->
+  {checkPrototypes} = opts
+
+  if _.isArray(value)
+    if toReturn.indexOf(value) != -1
+      return
+    toReturn.push(value)
+    for subValue in value
+      _extractParts(subValue, opts, toReturn)
+  else if _.isObject(value)
+    if toReturn.indexOf(value) != -1
+      return
+    toReturn.push(value)
+    for key, subValue of value
+      _extractParts(subValue, opts, toReturn)
+    if checkPrototypes
+      valuePrototype = Object.getPrototypeOf(value)
+      if valuePrototype != Object.prototype
+        _extractParts(valuePrototype, opts, toReturn)
+  return toReturn
+
+
+# For this helper, aValue should be a part of a or a primitive value.
+_checkValuesEqual = (aValue, bValue, opts, context) ->
+  {log} = opts
+  {aParts, bParts, aPartToBPart} = context
+
+  if log then console.log 'checkValuesEqual', aValue, bValue
+  if _.isArray(aValue) or _.isObject(aValue)
+    return _checkPartsEqual(aValue, bValue, opts, context)
+  else
+    return aValue == bValue
+
+# For this helper, aPart should be a part of a.
+_checkPartsEqual = (aPart, bPart, opts, context) ->
+  {log, checkPrototypes} = opts
+  {aParts, bParts, aPartToBPart} = context
+
+  if log then console.log 'checkPartsEqual', aPart, bPart
+
+  aPartIndex = aParts.indexOf(aPart)
+  if log then console.log '  aPartIndex', aPartIndex
+
+  bPartIndex = bParts.indexOf(bPart)
+  if log then console.log '  bPartIndex', bPartIndex
+  if aPartToBPart[aPartIndex]?
+    # aPart has a corresponding bPart recorded in aPartToBPart. This is all we
+    # need to check.
+    return aPartToBPart[aPartIndex] == bPartIndex
+
+  if aPartToBPart.indexOf(bPartIndex) != -1
+    # bPart is already claimed by a different a part!
+    return false
+
+  aPartToBPart[aPartIndex] = bPartIndex
+
+  if _.isArray(aPart)
+    if !_.isArray(bPart)
+      return false
+    if aPart.length != bPart.length
+      return false
+    for aSubValue, i in aPart
+      if !_checkValuesEqual(aSubValue, bPart[i], opts, context)
+        return false
+    return true
+  else if _.isObject(aPart)
+    if !_.isObject(bPart)
+      return false
+    if _.keys(aPart).length != _.keys(bPart).length
+      return false
+    for own key, aSubValue of aPart
+      if !_checkValuesEqual(aSubValue, bPart[key], opts, context)
+        return false
+    if checkPrototypes
+      aPartProto = Object.getPrototypeOf(aPart)
+      bPartProto = Object.getPrototypeOf(bPart)
+      if !(aPartProto == Object.prototype and bPartProto == Object.prototype)
+        # one of them is interesting!
+        if aPartProto == Object.prototype or bPartProto == Object.prototype
+          # one of them isn't interesting!
+          return false
+        if !_checkValuesEqual(aPartProto, bPartProto, opts, context)
+          return false
+
+    return true

--- a/src/Util/DeepEquality.coffee
+++ b/src/Util/DeepEquality.coffee
@@ -13,6 +13,10 @@ module.exports = DeepEquality = {}
 # cyclicDeepEqual compares two Javascript values. It is comfortable with values
 # which have cyclic references between their parts. In this case, it will ensure
 # that the two values have isomorphic reference graphs.
+#   Opts:
+#     checkPrototypes (default: true) -- whether equality of prototypes should
+#       be included in the checking process
+#     log (default: false) -- whether to log debugging info
 DeepEquality.cyclicDeepEqual = (a, b, opts) ->
   # PLAN:
   # Recursively check that each piece of a matches a corresponding piece of b.
@@ -20,8 +24,9 @@ DeepEquality.cyclicDeepEqual = (a, b, opts) ->
   # is possible with the following strategy:
   #  * The first time checkPartsEqual is called on aPart, it checks that bPart
   #    is a valid, unclaimed part of b, and then records the association between
-  #    aPart and bPart in an array called aPartToBPart. (This all happens before
-  #    any recursive calls.)
+  #    aPart and bPart in an array called aPartToBPart. checkPartsEqual can then
+  #    go on to check that aPart and bPart are in fact equal, largely via
+  #    recursive calls.
   #  * If checkPartsEqual is called on aPart a second time, this is the result
   #    of either a cyclic reference during the checking of aPart, or the
   #    checking of some unrelated part of a. In either case, it suffices to

--- a/test/DeepEquality.test.coffee
+++ b/test/DeepEquality.test.coffee
@@ -1,0 +1,122 @@
+test = require "tape"
+_ = require "underscore"
+
+
+DeepEquality = require "../src/Util/DeepEquality"
+cyclicDeepEqual = DeepEquality.cyclicDeepEqual
+
+
+test "Primitive values work", (t) ->
+  t.ok(cyclicDeepEqual(23, 23), "numbers")
+  t.ok(cyclicDeepEqual(null, null), "null")
+  t.notOk(cyclicDeepEqual(23, 24), "different numbers")
+  t.end()
+
+test "Simple objects work", (t) ->
+  t.ok(cyclicDeepEqual({a: 23, b: 2233}, {a: 23, b: 2233}), "same")
+  t.notOk(cyclicDeepEqual({a: 23, b: 100}, {a: 23, b: 2233}), "different value")
+  t.notOk(cyclicDeepEqual({a: 23}, {a: 23, b: 2233}), "first object smaller")
+  t.notOk(cyclicDeepEqual({a: 23, b: 2233}, {a: 23}), "seond object smaller")
+  t.end()
+
+test "Simple arrays work", (t) ->
+  t.ok(cyclicDeepEqual([23, 2233], [23, 2233]), "same")
+  t.notOk(cyclicDeepEqual([23, 100], [23, 2233]), "different value")
+  t.notOk(cyclicDeepEqual([23], [23, 2233]), "first array smaller")
+  t.notOk(cyclicDeepEqual([23, 2233], [23]), "second array smaller")
+  t.end()
+
+test "Compound objects work", (t) ->
+  t.ok(cyclicDeepEqual(
+    {a: {b: 23}, c: {d: 2233}},
+    {a: {b: 23}, c: {d: 2233}}), "same")
+  t.notOk(cyclicDeepEqual(
+    {a: {b: 23}, c: {d: 2233}},
+    {a: {b: 100}, c: {d: 2233}}), "different value (deep)")
+  t.end()
+
+test "Objects with multiply-referenced parts work", (t) ->
+  # Make object with multiply-referenced part
+  makeWith = ->
+    a = {}
+    b = {}
+    a.x = b
+    a.y = b
+    return a
+
+  # Make object without multiply-referenced part
+  makeWithout = ->
+    return {x: {}, y: {}}
+
+  t.deepEqual(makeWith(), makeWithout(),  "objects are deep-equal as values")
+  t.notOk(
+    cyclicDeepEqual(makeWith(), makeWithout()),
+    "objects are not cyclic-deep-equal")
+  t.notOk(
+    cyclicDeepEqual(makeWithout(), makeWith()),
+    "objects are not cyclic-deep-equal")
+
+  t.ok(
+    cyclicDeepEqual(makeWith(), makeWith()),
+    "first kind is cyclic-deep-equal to itself")
+  t.ok(
+    cyclicDeepEqual(makeWithout(), makeWithout()),
+    "second kind is cyclic-deep-equal to itself")
+
+  t.end()
+
+test "Self- and mutually-referential objects work", (t) ->
+  # Make self-referential object
+  makeSelf = ->
+    a = {}
+    a.x = a
+    return a
+
+  # Make mutually-referential object
+  makeMutually = ->
+    a = {}
+    b = {}
+    a.x = b
+    b.x = a
+    return a
+
+  # Note: makeSelf and makeMutually return infinitely deep objects which are
+  # "equal as values" (so they are not caught as unequal by pop-equals, which
+  # claims to compare cyclic objects).
+  t.notOk(
+    cyclicDeepEqual(makeSelf(), makeMutually()),
+    "objects are not cyclic-deep-equal")
+  t.notOk(
+    cyclicDeepEqual(makeMutually(), makeSelf()),
+    "objects are not cyclic-deep-equal")
+
+  # And just to check:
+  t.ok(
+    cyclicDeepEqual(makeSelf(), makeSelf()),
+    "first kind is cyclic-deep-equal to itself")
+  t.ok(
+    cyclicDeepEqual(makeMutually(), makeMutually()),
+    "second kind is cyclic-deep-equal to itself")
+
+  t.end()
+
+test "Prototypes are checked appropriately", (t) ->
+  make1 = ->
+    a = {x: {}, y: {}}
+    b = {}
+    Object.setPrototypeOf(a.x, b)
+    return a
+
+  make2 = ->
+    return {x: {}, y: {}}
+
+  t.ok(
+    cyclicDeepEqual(make1(), make2(), {checkPrototypes: false})
+    "test objects are equal aside from prototypes")
+  t.notOk(
+    cyclicDeepEqual(make1(), make2())
+    "test objects are not equal if you check prototypes")
+  t.ok(cyclicDeepEqual(make1(), make1()))
+  t.ok(cyclicDeepEqual(make2(), make2()))
+
+  t.end()

--- a/test/Serializer.test.coffee
+++ b/test/Serializer.test.coffee
@@ -1,0 +1,122 @@
+test = require "tape"
+_ = require "underscore"
+
+
+Serializer = require "../src/Storage/Serializer"
+DeepEquality = require "../src/Util/DeepEquality"
+{cyclicDeepEqual} = DeepEquality
+
+
+roundTrip = (value) ->
+  serializer = new Serializer([])
+  serializedObject = serializer.jsonify(value)
+  serializedString = JSON.stringify(serializedObject)
+
+  deserializer = new Serializer([])
+  deserializedString = JSON.parse(serializedString)
+  deserializedObject = deserializer.dejsonify(deserializedString)
+
+  return deserializedObject
+
+testRoundTrip = (t, value) ->
+  # Note: Since serializing actually mutates the original object by adding IDs,
+  # we don't have to strip IDs from the output.
+
+  # TODO: We should be skeptical of the fact that serializing mutates the
+  # original object.
+
+  roundTripValue = roundTrip(value)
+  t.ok(
+    cyclicDeepEqual(value, roundTripValue),
+    "round trip value should equal original value")
+
+stripIds = (value) ->
+  if _.isArray(value)
+    return (stripIds(subValue) for subValue in value)
+  else if _.isObject(value)
+    return _.mapObject(_.omit(value, 'id'), stripIds)
+  else
+    return value
+
+test "Primitive values work", (t) ->
+  testRoundTrip(t, 23)
+  testRoundTrip(t, "primitive string")
+  testRoundTrip(t, false)
+  testRoundTrip(t, undefined)
+  testRoundTrip(t, null)
+  t.end()
+
+test "Simple objects work", (t) ->
+  testRoundTrip(t, {a: 23})
+  t.end()
+
+test "Compound objects work", (t) ->
+  testRoundTrip(t, {a: {b: 23}, c: {d: 2233}})
+  t.end()
+
+test "Objects with multiply-referenced parts work", (t) ->
+  a = {}
+  b = {}
+  a.x = b
+  a.y = b
+  testRoundTrip(t, a)
+  t.end()
+
+test "Self-referential objects work", (t) ->
+  a = {}
+  a.x = a
+  testRoundTrip(t, a)
+  t.end()
+
+test "Mutually-referential objects work", (t) ->
+  a = {}
+  b = {}
+  a.x = b
+  b.x = a
+  testRoundTrip(t, a)
+  t.end()
+
+test "Prototypes are serialized", (t) ->
+  a = {x: 10}
+  b = {y: 10}
+  Object.setPrototypeOf(a, b)
+  testRoundTrip(t, a)
+  t.end()
+
+test "Double-underscored properties are not serialized", (t) ->
+  a = {x: 10, __secret: "my secret"}
+  aActual = stripIds(roundTrip(a))
+  aExpected = {x: 10}
+  t.ok(cyclicDeepEqual(aActual, aExpected))
+  t.end()
+
+test "Functions are not serialized", (t) ->
+  a = {x: 10, y: (a) -> a * a}
+  aActual = stripIds(roundTrip(a))
+  aExpected = {x: 10}
+  t.ok(cyclicDeepEqual(aActual, aExpected))
+  t.end()
+
+test "Builtins work", (t) ->
+  secretCode = "ABRACADABRA"
+
+  builtin = {secretCode: secretCode}
+  a = {x: builtin}
+
+  serializer = new Serializer([builtin])
+  serializedObject = serializer.jsonify(a)
+  serializedString = JSON.stringify(serializedObject)
+
+  t.equal(
+    serializedString.indexOf("ABRACADABRA"), -1,
+    "serialized object does not contain secret word")
+
+  deserializer = new Serializer([builtin])
+  deserializedString = JSON.parse(serializedString)
+  deserializedObject = deserializer.dejsonify(deserializedString)
+
+  t.ok(
+    cyclicDeepEqual(a, deserializedObject),
+    "deserialized object equals original object")
+
+  t.end()


### PR DESCRIPTION
I wrote some tests for `Serializer`, which required writing a "super deep equal" checker. I added some tests for that critter too.

Comments are very welcome. (In particular, I'd be happy to remove the logging, though it is pretty useful for debugging.)

Note: I have no particularly strong belief that `Serializer` needed tests. This was just an excuse to make sure I knew how it worked, and to scratch a Saturday-morning intellectual itch.
