### PR TITLE
stop drawing control points for empty spreads

### DIFF
--- a/src/View/Canvas.coffee
+++ b/src/View/Canvas.coffee
@@ -32,8 +32,8 @@ R.create "Canvas",
         className: R.cx {
           LayoutMode: true
           FullScreen: layout.fullScreen
-          "icon-fullscreen": !layout.fullScreen 
-          "icon-edit": layout.fullScreen 
+          "icon-fullscreen": !layout.fullScreen
+          "icon-edit": layout.fullScreen
         }
         onClick: @_toggleLayout
       }
@@ -150,6 +150,7 @@ R.create "Canvas",
     return [] unless selectedParticularElement
 
     matrix = selectedParticularElement.accumulatedMatrix()
+    return [] unless matrix
     matrix = @_viewMatrix().compose(matrix)
 
     controlPoints = selectedParticularElement.element.controlPoints()


### PR DESCRIPTION
The trouble in #30 was caused by `Canvas::_controlPoints` calling `ParticularElement::accumulatedMatrix`, which uses `SpreadEnv::resolveWithDefault`. This breaks when the spread is empty.

This fixes the trouble, by reverting in this situation to the no-selected-particular-element behavior.
