### PR TITLE
handle circular-reference errors in attributes instead of breaking

### DIFF
--- a/src/Model/Attribute.coffee
+++ b/src/Model/Attribute.coffee
@@ -20,8 +20,8 @@ module.exports = Attribute = Node.createVariant
     @value = Dataflow.cell(@_value.bind(this))
 
   _value: ->
-    if @circularReferenceError
-      return @circularReferenceError
+    if @__circularReferenceError
+      return @__circularReferenceError
 
     # Optimization
     if @isNumber()
@@ -106,11 +106,11 @@ module.exports = Attribute = Node.createVariant
       recurse(this)
     catch error
       if error instanceof CircularReferenceError
-        @circularReferenceError = error
+        @__circularReferenceError = error
         return []
       else
         throw error
-    @circularReferenceError = null
+    @__circularReferenceError = null
     dependencies = _.unique(dependencies)
     return dependencies
 

--- a/src/View/Expression.coffee
+++ b/src/View/Expression.coffee
@@ -35,7 +35,7 @@ R.create "Value",
     value = @props.value
     R.span {className: "Value"},
       if value instanceof Error
-        "(Error)"
+        "(" + value + ")"
       else if _.isFunction(value)
         "(Function)"
       else if value instanceof Dataflow.Spread

--- a/test/Attribute.test.coffee
+++ b/test/Attribute.test.coffee
@@ -51,7 +51,7 @@ test "Dependencies work", (t) ->
 
   t.equal(a.value(), 120, 'value works')
   t.deepEqual(a.dependencies(), [b, c], 'dependencies works')
-  t.equal(a.checkForCircularReferenceError(), null, 'checkForCircularReferenceError works')
+  t.equal(a.circularReferencePath(), null, 'circularReferencePath works')
   t.end()
 
 test "Dependencies work with circular references", (t) ->
@@ -63,9 +63,11 @@ test "Dependencies work with circular references", (t) ->
   b.setExpression("$$$c$$$", {$$$c$$$: c})
   c.setExpression("$$$b$$$", {$$$b$$$: b})
 
-  expectedError = new Attribute.CircularReferenceError([a, b, c, b])
+  expectedCircularReferencePath = [a, b, c, b]
+  expectedError = new Attribute.CircularReferenceError(
+    expectedCircularReferencePath)
 
   t.deepEqual(a.value(), expectedError, 'value works')
   t.deepEqual(a.dependencies(), [b, c], 'dependencies works')
-  t.deepEqual(a.checkForCircularReferenceError(), expectedError, 'checkForCircularReferenceError works')
+  t.deepEqual(a.circularReferencePath(), expectedCircularReferencePath, 'circularReferencePath works')
   t.end()

--- a/test/Attribute.test.coffee
+++ b/test/Attribute.test.coffee
@@ -39,3 +39,33 @@ test "Changes recompile", (t) ->
   b.setExpression("$$$a$$$ * 3", {$$$a$$$: a})
   t.equal(b.value(), 30)
   t.end()
+
+test "Dependencies work", (t) ->
+  a = Attribute.createVariant({label: 'a'})
+  b = Attribute.createVariant({label: 'b'})
+  c = Attribute.createVariant({label: 'c'})
+
+  a.setExpression("$$$b$$$ * 2", {$$$b$$$: b})
+  b.setExpression("$$$c$$$ * 3", {$$$c$$$: c})
+  c.setExpression("20")
+
+  t.equal(a.value(), 120, 'value works')
+  t.deepEqual(a.dependencies(), [b, c], 'dependencies works')
+  t.equal(a.checkForCircularReferenceError(), null, 'checkForCircularReferenceError works')
+  t.end()
+
+test "Dependencies work with circular references", (t) ->
+  a = Attribute.createVariant({label: 'a'})
+  b = Attribute.createVariant({label: 'b'})
+  c = Attribute.createVariant({label: 'c'})
+
+  a.setExpression("$$$b$$$", {$$$b$$$: b})
+  b.setExpression("$$$c$$$", {$$$c$$$: c})
+  c.setExpression("$$$b$$$", {$$$b$$$: b})
+
+  expectedError = new Attribute.CircularReferenceError([a, b, c, b])
+
+  t.deepEqual(a.value(), expectedError, 'value works')
+  t.deepEqual(a.dependencies(), [b, c], 'dependencies works')
+  t.deepEqual(a.checkForCircularReferenceError(), expectedError, 'checkForCircularReferenceError works')
+  t.end()


### PR DESCRIPTION
Intended to fix #13.

Notes:
- I don't really know how the evaluation / rendering cycle works yet. Experimentation shows that whenever attribute expressions change, `Attribute::dependencies` is always called at some point before `Attribute::value`. I rely upon this, by setting the error state in `Attribute::dependencies` and reading it in `Attribute::value`. I feel uncertain about the consequences of this, especially in edge cases like deserialized models. Let me know if there is a better way of handling this.
- Recursive shapes still seem to work. :smile:
- I updated the value display to include error text. This allows the user to see the cause of the error, rather than just "(Error)".

Screenshot:
<img width="441" alt="error-report" src="https://cloud.githubusercontent.com/assets/643799/11323104/c0d6d40e-90bd-11e5-89f1-4c05da7ee3f7.png">
