### PR TITLE
fix RightPanelContainer width

### DIFF
--- a/style/index.styl
+++ b/style/index.styl
@@ -111,6 +111,7 @@ RightResizeWidth = 10px
   border-right 1px solid #ccc
 
 .RightPanel
+  position relative
   // this panel should not shrink
   flex-shrink 0
   box-sizing border-box


### PR DESCRIPTION
Currently, RightPanelContainer is set to 100% width with absolute positioning, but since its parents are all statically positioned, it ends up taking its width from the window itself. This makes the div super-wide, which messes up wrapping of expressions and things like that. (For instance, the text headings on the outline and inspector are missing right now, since they're off the right side of the screen.)

This fixes the problem by setting RightPanel to relative positioning like CreatePanel, returning the width behavior to what it was like before #24.
