### PR TITLE
Change ReferenceToken wrapping method

### DIFF
--- a/style/index.styl
+++ b/style/index.styl
@@ -460,7 +460,7 @@ HeaderSize = 18px
 .ReferenceToken
   border-radius 20px
   padding 0 0.75em
-  white-space nowrap
+  display inline-block
 
 .SpreadValue
   &:before


### PR DESCRIPTION
`white-space nowrap` actually forces the entire attribute expression to be unwrapped. We only want the token itself to be unwrapped. `display inline-block` achieves this.
