### PR TITLE
Add Firebase-backed 'Share' button

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "codemirror": "^5.4.0",
+    "firebase": "^2.3.2",
     "keymaster": "^1.6.2",
     "numeric": "^1.2.6",
+    "q": "^1.4.1",
     "query-string": "^2.4.1",
     "react": "^0.13.3",
     "underscore": "^1.8.3"

--- a/settings/firebaseRules
+++ b/settings/firebaseRules
@@ -1,0 +1,26 @@
+{
+  "rules": {
+    ".read": false,
+    ".write": false,
+
+    "drawings": {
+      ".read": true,
+
+      "$drawing": {
+        ".write": "!data.exists() && newData.exists()            // this is a create (not a delete or update)
+                   && auth != null                               // you are authenticated
+                   && newData.child('uid').val() == auth.uid     // you are including a uid which matches your auth uid
+                   && root.child('users/' + auth.uid).exists()"  // your uid is registered in `users`
+      }
+    },
+
+    "users": {
+      "$uid": {
+        ".write": "newData.exists()      // this is a create or an update (not a delete)
+                   && auth != null       // you are authenticated
+                   && $uid == auth.uid"  // you are editing the user entry corresponding to your auth uid
+
+      }
+    }
+  }
+}

--- a/src/Storage/FirebaseAccess.coffee
+++ b/src/Storage/FirebaseAccess.coffee
@@ -1,0 +1,68 @@
+Firebase = require "firebase"
+FirebasePromises = require "../Util/FirebasePromises"
+Q = require "q"
+
+
+###
+Manages Apparatus's use of Firebase for drawing storage.
+###
+
+
+module.exports = class FirebaseAccess
+  constructor: ->
+    # This actually establishes a connection to Firebase and checks the current
+    # auth status, so don't make a FirebaseAccess unless you're cool with that.
+    @ref = new Firebase("https://aprtus.firebaseio.com/")
+    @authData = @ref.getAuth();
+
+  # Returns a promise to go through a login process.
+  loginPromise: ->
+    options = {scope: "email"}
+    return FirebasePromises.authWithOAuthPopupPromise(@ref, "google", options)
+      .then (authData) =>
+        # save auth data locally
+        @authData = authData
+
+        # save auth data to server
+        userRef = @ref.child("users").child(@authData.uid)
+        newUserData =
+          date: Firebase.ServerValue.TIMESTAMP
+          email: @authData.google.email
+        return FirebasePromises.setPromise(userRef, newUserData)
+
+  # Returns a promise to go through a login process, if the user isn't logged in
+  # already.
+  loginIfNecessaryPromise: ->
+    if not @authData
+      return @loginPromise()
+    else
+      return Q()  # simple success
+
+  saveUserInformationPromise: ->
+    @loginIfNecessaryPromise()
+
+  # Given a JSON string of a drawing, returns a promise to save the drawing's
+  # data and return the drawing key. Will go into a login process, if necessary.
+  saveDrawingPromise: (drawing) ->
+    @loginIfNecessaryPromise().then =>
+      drawingsRef = @ref.child("drawings")
+      newDrawingData =
+        uid: @authData.uid
+        date: Firebase.ServerValue.TIMESTAMP
+        source: drawing
+      return FirebasePromises.pushPromise(drawingsRef, newDrawingData)
+        .then (newDrawingRef) -> newDrawingRef.key()
+
+  # Given a drawing key, returns a promise to return the drawing's data block.
+  loadDrawingPromise: (key) ->
+    drawingRef = @ref.child("drawings").child(key)
+    return FirebasePromises.getValuePromise(drawingRef)
+      .then (drawingDataSnapshot) =>
+        if not drawingDataSnapshot.exists()
+          throw new DrawingNotFoundError()
+        drawingData = drawingDataSnapshot.val()
+        return drawingData
+
+
+# The error that occurs when you try to load a drawing that doesn't exist.
+FirebaseAccess.DrawingNotFoundError = class DrawingNotFoundError

--- a/src/Util/FirebasePromises.coffee
+++ b/src/Util/FirebasePromises.coffee
@@ -1,0 +1,70 @@
+Firebase = require "firebase"
+Q = require "q"
+
+
+module.exports = FirebasePromises = {}
+
+
+###
+Simple non-Apparatus-specific promises for use with Firebase
+###
+
+
+# Like ref.authWithOAuthPopupPromise(provider, ..., options). Resolves to the
+# auth data object if successful.
+FirebasePromises.authWithOAuthPopupPromise = (ref, provider, options) ->
+  deferred = Q.defer()
+
+  # traditional onComplete API, but non-traditional placement of `options` argument
+  onComplete = deferred.makeNodeResolver()
+
+  ref.authWithOAuthPopup(provider, onComplete, options)
+
+  return deferred.promise
+
+
+# Like ref.once('value', ...). Resolves to the resulting data snapshot.
+FirebasePromises.getValuePromise = (ref) ->
+  deferred = Q.defer()
+
+  successCallback = (dataSnapshot) ->
+    deferred.resolve(dataSnapshot)
+  failureCallback = (error) ->
+    deferred.reject(error)
+
+  ref.once('value', successCallback, failureCallback)
+
+  return deferred.promise
+
+
+# Like ref.push(value, ...). Resolves to the ref of the pushed node if the push
+# is successful.
+FirebasePromises.pushPromise = (ref, value) ->
+  deferred = Q.defer()
+
+  # NOTE: non-traditional onComplete API
+  onComplete = (maybeError) ->
+    if maybeError
+      deferred.reject(maybeError)
+    else
+      deferred.resolve(pushedRef)
+
+  pushedRef = ref.push(value, onComplete)
+
+  return deferred.promise
+
+
+# Like ref.set(value, ...). Resolves (to nothing) if the push is successful.
+FirebasePromises.setPromise = (ref, value) ->
+  deferred = Q.defer()
+
+  # NOTE: non-traditional onComplete API
+  onComplete = (maybeError) ->
+    if maybeError
+      deferred.reject(maybeError)
+    else
+      deferred.resolve()
+
+  ref.set(value, onComplete)
+
+  return deferred.promise

--- a/src/View/Menubar.coffee
+++ b/src/View/Menubar.coffee
@@ -20,6 +20,8 @@ R.create "Menubar",
       R.MenubarItem {title: "New", isDisabled: false, fn: @_new}
       R.MenubarItem {title: "Load", isDisabled: false, fn: @_load}
       R.MenubarItem {title: "Save", isDisabled: false, fn: @_save}
+      if editor.experimental
+        R.MenubarItem {title: "Share", isDisabled: false, fn: @_share}
 
       R.div {className: "MenubarSeparator"}
 
@@ -80,6 +82,10 @@ R.create "Menubar",
   _save: ->
     {editor} = @context
     editor.saveToFile()
+
+  _share: ->
+    {editor} = @context
+    editor.saveToFirebase()
 
   _undo: ->
     {editor} = @context


### PR DESCRIPTION
This is really skeletal right now. Here's how it works:
- **Writing:** If you press the "Share" button, you are asked to login with Google. If this is successful, the drawing is uploaded to Firebase and a modal pops up with a link to copy.
  - I could remove the Google-login step, but I was worried about abuse if we had a totally open system. This puts a tiny bit of accountability in – we can ban accounts if they spam the database.
  - The login token is saved in the browser and lasts as long as we want it to. I put down two weeks.
  - The link-copying modal is really janky.
- **Reading:** The link you get looks like `http://aprt.us/editor/?loadFirebase=-K4vibVnZIyndlfTFzfl`. This acts just like `http://aprt.us/editor/?load=doc/examples/Bezier.json`. It doesn't take any auth.
  - There's no good UI for error-reporting here, but the code paths are in place.

My hope is that this is a big improvement on the existing JSON-attachment communications flow.
