### PR TITLE
Upgrade to React 0.14

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
 </head>
 <body>
 
+<div id="apparatus-container"></div>
+
 <script src="dist/apparatus.js"></script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "email": "tqs@alum.mit.edu",
     "url": "http://tobyschachman.com"
   },
+  "repository" : {
+   "type" : "git",
+   "url" : "http://github.com/cdglabs/apparatus.git"
+  },
   "dependencies": {
     "codemirror": "^5.4.0",
     "firebase": "^2.3.2",
@@ -15,7 +19,8 @@
     "numeric": "^1.2.6",
     "q": "^1.4.1",
     "query-string": "^2.4.2",
-    "react": "^0.13.3",
+    "react": "^0.14.8",
+    "react-dom": "^0.14.8",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/src/View/Canvas.coffee
+++ b/src/View/Canvas.coffee
@@ -424,7 +424,7 @@ R.create "Canvas",
 
   _rect: ->
     return @_rectCached if @_rectCached?
-    el = @getDOMNode()
+    el = R.findDOMNode(@)
     return @_rectCached = el.getBoundingClientRect()
 
   _editingElement: ->

--- a/src/View/Expression.coffee
+++ b/src/View/Expression.coffee
@@ -57,7 +57,7 @@ R.create "SpreadValue",
     R.span {className: "SpreadValue"},
       for index in [0...Math.min(spread.items.length, maxSpreadItems)]
         value = spread.items[index]
-        R.span {className: "SpreadValueItem"},
+        R.span {key: index, className: "SpreadValueItem"},
           R.Value {value: value}
       if spread.items.length > maxSpreadItems
         "..."

--- a/src/View/ExpressionCode.coffee
+++ b/src/View/ExpressionCode.coffee
@@ -39,7 +39,7 @@ R.create "ExpressionCode",
     {component: this}
 
   componentDidMount: ->
-    el = @getDOMNode()
+    el = R.findDOMNode(@)
 
     @mirror = CodeMirror(el, {
       mode: "javascript"

--- a/src/View/Generic/EditableText.coffee
+++ b/src/View/Generic/EditableText.coffee
@@ -22,20 +22,20 @@ R.create "EditableText",
     @_refresh()
     # Autofocus if empty string value.
     if @props.value == "" or !@props.value
-      @getDOMNode().focus()
+      R.findDOMNode(@).focus()
 
   componentDidUpdate: ->
     @_refresh()
 
   _refresh: ->
-    el = @getDOMNode()
+    el = R.findDOMNode(@)
     if el.textContent != @props.value
       el.textContent = @props.value
     @_isDirty = false
 
   _onInput: ->
     @_isDirty = true
-    el = @getDOMNode()
+    el = R.findDOMNode(@)
     newValue = el.textContent
     @props.setValue(newValue)
 

--- a/src/View/Generic/HTMLCanvas.coffee
+++ b/src/View/Generic/HTMLCanvas.coffee
@@ -26,7 +26,7 @@ R.create "HTMLCanvas",
     @_canvasIsSized = false
 
   _refresh: ->
-    canvas = @getDOMNode()
+    canvas = R.findDOMNode(@)
 
     if @_canvasIsSized
       canvas.width = canvas.width

--- a/src/View/Inspector.coffee
+++ b/src/View/Inspector.coffee
@@ -79,10 +79,10 @@ R.create "NovelAttributesList",
     {project} = @context
 
     R.div {className: "AttributesList"},
-      for attribute in element.allAttributes()
+      for attribute, i in element.allAttributes()
         shouldShow = attribute.isNovel() or attribute.isVariantOf(Model.Variable)
         if shouldShow
-          R.AttributeRow {attribute}
+          R.AttributeRow {key: i, attribute}
       if element == project.editingElement
         R.div {className: "AddVariableRow"},
           R.button {className: "AddButton Interactive", onClick: @_addVariable}

--- a/src/View/Outline.coffee
+++ b/src/View/Outline.coffee
@@ -175,7 +175,7 @@ R.create "OutlineItem",
     {element} = @props
     {dragManager} = @context
 
-    el = @getDOMNode()
+    el = R.findDOMNode(@)
     outlineTreeEl = Util.closest(el, ".OutlineTree")
     outlineEl = Util.closest(el, ".Outline")
     rect = outlineTreeEl.getBoundingClientRect()

--- a/src/View/Picture.coffee
+++ b/src/View/Picture.coffee
@@ -58,7 +58,7 @@ R.create "Picture",
 
   _size: ->
     return @_cachedSize if @_cachedSize
-    el = @getDOMNode()
+    el = R.findDOMNode(@)
     rect = el.getBoundingClientRect()
     {width, height} = rect
     return @_cachedSize = {width, height}

--- a/src/View/R.coffee
+++ b/src/View/R.coffee
@@ -1,4 +1,5 @@
 React = require "react"
+ReactDOM = require "react-dom"
 _ = require "underscore"
 
 Model = require "../Model/Model"
@@ -24,10 +25,10 @@ R.AnnotateMixin = {
   componentDidUpdate: -> @_annotateDOMNode()
   componentWillUnmount: -> @_clearAnnotation()
   _annotateDOMNode: ->
-    el = @getDOMNode()
+    el = ReactDOM.findDOMNode(@)
     el.annotation = @annotation()
   _clearAnnotation: ->
-    el = @getDOMNode()
+    el = ReactDOM.findDOMNode(@)
     delete el.annotation
 }
 
@@ -44,7 +45,8 @@ R.create = (name, spec) ->
   R[name] = React.createFactory(component)
 
 
-R.render = React.render
+R.render = ReactDOM.render
+R.findDOMNode = ReactDOM.findDOMNode
 
 
 desugarPropTypes = (propTypes) ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -30,7 +30,7 @@ Apparatus.editor = editor
 
 render = ->
   Dataflow.run ->
-    R.render(R.Editor({editor}), document.body)
+    R.render(R.Editor({editor}), document.getElementById("apparatus-container"))
 
 render()
 
@@ -75,4 +75,3 @@ refreshEventNames = [
 
 for eventName in refreshEventNames
   window.addEventListener(eventName, refresh)
-


### PR DESCRIPTION
This was easy to do, and it helps for compatibility with external React components we might want to add, so let's do it! I poked around, and Apparatus still seems to work, so that's good. I eliminated all console errors / warnings I found. Please take a look!

**Notes:**
- [As you mentioned](https://github.com/cdglabs/apparatus/commit/3d678e9a89c62d8940b3a894aeead7e03af5c178), the build process could use a fix-up. I was conservative in this change and only did basic clean-up.
- I removed the `thirdparty` directory, since I think React is already being included via `vendor.js`, but please take a look at that.
- React advises against mounting a component directly to `<body />`, since third-party extensions sometimes mess with `<body />`. Hopefully my change to `index.html` is OK?
