### PR TITLE
Added ability to select anchors with mouse

### DIFF
--- a/src/Model/Element.coffee
+++ b/src/Model/Element.coffee
@@ -170,6 +170,8 @@ module.exports = Element = Node.createVariant
 
   matrix: ->
     matrix = new Util.Matrix()
+    for position in @childrenOfType(Model.Position)
+      matrix = matrix.compose(position.matrix())
     for transform in @childrenOfType(Model.Transform)
       matrix = matrix.compose(transform.matrix())
     return matrix

--- a/src/Model/Model.coffee
+++ b/src/Model/Model.coffee
@@ -92,6 +92,28 @@ Model.Transform.addChildren [
 ]
 
 
+Model.Position = Model.Component.createVariant
+  label: "Position"
+  matrix: ->
+    {x, y} = @getAttributesValuesByName()
+    return Util.Matrix.naturalConstruct(x, y, 1, 1, 0)
+  defaultAttributesToChange: ->
+    {x, y} = @getAttributesByName()
+    return [x, y]
+  controllableAttributes: ->
+    {x, y} = @getAttributesByName()
+    return [x, y]
+  controlPoints: ->
+    {x, y} = @getAttributesByName()
+    return [
+      {point: [0, 0], attributesToChange: [x, y], filled: true}
+    ]
+
+Model.Position.addChildren [
+  createAttribute("X", "x", "0.00")
+  createAttribute("Y", "y", "0.00")
+]
+
 
 Model.Fill = Model.Component.createVariant
   label: "Fill"
@@ -122,19 +144,25 @@ Model.Shape.addChildren [
 ]
 
 
+Model.Point = Model.Element.createVariant()
+Model.Point.addChildren [
+  Model.Position.createVariant()
+]
+
+
 Model.Group = Model.Shape.createVariant
   label: "Group"
   graphicClass: Graphic.Group
 
 
-Model.Anchor = Model.Shape.createVariant
+Model.Anchor = Model.Point.createVariant
   label: "Anchor"
   graphicClass: Graphic.Anchor
 
 createAnchor = (x, y) ->
   anchor = Model.Anchor.createVariant()
-  transform = anchor.childOfType(Model.Transform)
-  attributes = transform.getAttributesByName()
+  position = anchor.childOfType(Model.Position)
+  attributes = position.getAttributesByName()
   attributes.x.setExpression(x)
   attributes.y.setExpression(y)
   return anchor


### PR DESCRIPTION
@electronicwhisper: I wanted to play around with adding more point-like elements, so as a warm-up I added support for selecting & dragging anchor points. PTAL!

(((
Things that seemed sort of funky to me but eventually turned out to make perfect sense:
1. You still need to double-click your way down to the anchor from the path. I didn't expect this, before implementing the feature. But I should have, since it fits with Apparatus's general selection method.
2. Since anchor points are children of the parent path, their highlights will show up when the parent is highlighted. That means putting your mouse near one anchor results in all the fellow anchors being highlighted. But again, this fits with how Apparatus's visualizes single- and double-click targets: double-click targets are never visualized.

This is an interesting point to revisit: is there a good way to signify the double-click affordance?
)))
