### PR TITLE
Add labels and lineage tools

### DIFF
--- a/src/Model/Attribute.coffee
+++ b/src/Model/Attribute.coffee
@@ -8,6 +8,8 @@ Model = require "./Model"
 
 
 module.exports = Attribute = Node.createVariant
+  label: "Attribute"
+
   constructor: ->
     # Call "super" constructor
     Node.constructor.apply(this, arguments)

--- a/src/Model/Element.coffee
+++ b/src/Model/Element.coffee
@@ -7,6 +7,8 @@ Util = require "../Util/Util"
 
 
 module.exports = Element = Node.createVariant
+  label: "Element"
+
   constructor: ->
     # Call "super" constructor
     Node.constructor.apply(this, arguments)

--- a/src/Model/Link.coffee
+++ b/src/Model/Link.coffee
@@ -1,6 +1,8 @@
 Node = require "./Node"
 
-module.exports = Link = Node.createVariant {
+module.exports = Link = Node.createVariant
+  label: "Link"
+
   setTarget: (@_target) ->
 
   target: ->
@@ -25,4 +27,3 @@ module.exports = Link = Node.createVariant {
       cursor = nextCursor
 
     return cursor
-}

--- a/src/Model/Model.coffee
+++ b/src/Model/Model.coffee
@@ -21,13 +21,16 @@ Model.Element = require "./Element"
 Model.Editor = require "./Editor"
 
 
-Model.Variable = Model.Attribute.createVariant()
+Model.Variable = Model.Attribute.createVariant
+  label: "Variable"
 
 # Links an Element to the Attributes it controls.
-Model.ControlledAttributeLink = Model.Link.createVariant()
+Model.ControlledAttributeLink = Model.Link.createVariant
+  label: "ControlledAttributeLink"
 
 # Links an Attribute to the Attributes it references in its expression.
-Model.ReferenceLink = Model.Link.createVariant()
+Model.ReferenceLink = Model.Link.createVariant
+  label: "ReferenceLink"
 
 createAttribute = (label, name, exprString) ->
   attribute = Model.Attribute.createVariant
@@ -41,6 +44,8 @@ createAttribute = (label, name, exprString) ->
 # =============================================================================
 
 Model.Component = Model.Node.createVariant
+  label: "Component"
+
   attributes: ->
     @childrenOfType(Model.Attribute)
 
@@ -66,6 +71,7 @@ Model.Component = Model.Node.createVariant
 
 Model.Transform = Model.Component.createVariant
   label: "Transform"
+
   matrix: ->
     {x, y, sx, sy, rotate} = @getAttributesValuesByName()
     return Util.Matrix.naturalConstruct(x, y, sx, sy, rotate)
@@ -116,7 +122,9 @@ Model.Stroke.addChildren [
 # Elements
 # =============================================================================
 
-Model.Shape = Model.Element.createVariant()
+Model.Shape = Model.Element.createVariant
+  label: "Shape"
+
 Model.Shape.addChildren [
   Model.Transform.createVariant()
 ]
@@ -141,6 +149,7 @@ createAnchor = (x, y) ->
 
 
 Model.PathComponent = Model.Component.createVariant
+  devLabel: "PathComponent"
   label: "Path"
   graphicClass: Graphic.PathComponent
 
@@ -176,6 +185,7 @@ Model.Rectangle.addChildren [
 
 
 Model.TextComponent = Model.Component.createVariant
+  devLabel: "TextComponent"
   label: "Text"
   graphicClass: Graphic.TextComponent
 

--- a/test/Node.test.coffee
+++ b/test/Node.test.coffee
@@ -83,3 +83,56 @@ test "adding a variant as a child (to create recursion) does not crash / overflo
     cursor = cursor.children()[0]
 
   t.end()
+
+test "lineages basically work", (t) ->
+  b = Node.createVariant()
+  c = Node.createVariant()
+  b.addChild(c)
+
+  a2 = Node.createVariant()
+  b2 = b.createVariant()
+  a2.addChild(b2)
+  c2 = c.findVariantWithHead(b2)
+
+  b3 = b2.createVariant()
+  c3 = c2.findVariantWithHead(b3)
+
+  t.deepEqual(b.masterLineage(), [b, Node])
+  t.deepEqual(c.masterLineage(), [c, Node])
+  t.deepEqual(a2.masterLineage(), [a2, Node])
+  t.deepEqual(b2.masterLineage(), [b2, b, Node])
+  t.deepEqual(c2.masterLineage(), [c2, c, Node])
+  t.deepEqual(b3.masterLineage(), [b3, b2, b, Node])
+  t.deepEqual(c3.masterLineage(), [c3, c2, c, Node])
+
+  t.deepEqual(b.parentThenMasterLineage(),
+    [[b, "master"], [Node, "end"]])
+  t.deepEqual(c.parentThenMasterLineage(),
+    [[c, "parent"], [b, "master"], [Node, "end"]])
+  t.deepEqual(a2.parentThenMasterLineage(),
+    [[a2, "master"], [Node, "end"]])
+  t.deepEqual(b2.parentThenMasterLineage(),
+    [[b2, "parent"], [a2, "master"], [Node, "end"]])
+  t.deepEqual(c2.parentThenMasterLineage(),
+    [[c2, "parent"], [b2, "parent"], [a2, "master"], [Node, "end"]])
+  t.deepEqual(b3.parentThenMasterLineage(),
+    [[b3, "master"], [b2, "parent"], [a2, "master"], [Node, "end"]])
+  t.deepEqual(c3.parentThenMasterLineage(),
+    [[c3, "parent"], [b3, "master"], [b2, "parent"], [a2, "master"], [Node, "end"]])
+
+  t.deepEqual(b.headThenMasterLineage(),
+    [[b, "master"], [Node, "end"]])
+  t.deepEqual(c.headThenMasterLineage(),
+    [[c, "master"], [Node, "end"]])
+  t.deepEqual(a2.headThenMasterLineage(),
+    [[a2, "master"], [Node, "end"]])
+  t.deepEqual(b2.headThenMasterLineage(),
+    [[b2, "master"], [b, "master"], [Node, "end"]])
+  t.deepEqual(c2.headThenMasterLineage(),
+    [[c2, "head"], [b2, "master"], [b, "master"], [Node, "end"]])
+  t.deepEqual(b3.headThenMasterLineage(),
+    [[b3, "master"], [b2, "master"], [b, "master"], [Node, "end"]])
+  t.deepEqual(c3.headThenMasterLineage(),
+    [[c3, "head"], [b3, "master"], [b2, "master"], [b, "master"], [Node, "end"]])
+
+  t.end()


### PR DESCRIPTION
A few tools to make development easier:
- I added `label`s to every node I could find. It makes digging through the node graph way easier.
- When my desired label conflicted with a display label (like how `TextComponent` has the user-friendly but developer-unfriendly label `Text`), I added `__devLabel` instead.
- I added some "lineage" tools which help trace where a node is in the graph. Combined with all the new labels, these make life much more sane in Apparatus-node-graph-town.

PTAL @electronicwhisper.

🎄🎄🎄🎄🎄
