### PR TITLE
Added findUnnecessaryNodes

### DIFF
--- a/src/Util/NodeVisitor.coffee
+++ b/src/Util/NodeVisitor.coffee
@@ -1,0 +1,38 @@
+# TODO: what about hatching?
+
+module.exports = class NodeVisitor
+  constructor: ({@onVisit, @linksToFollow}) ->
+    @visitedNodes = []
+
+  visit: (node) ->
+    if @hasVisited(node)
+      return
+
+    node.__visitors.push(this)
+    @visitedNodes.push(node)
+
+    @onVisit(node) if @onVisit
+
+    if @linksToFollow.master
+      master = node.master()
+      @visit(master) if master
+    if @linksToFollow.variants
+      @visit(variant) for variant in node.variants()
+    if @linksToFollow.parent
+      parent = node.parent()
+      @visit(parent) if parent
+    if @linksToFollow.children
+      @visit(child) for child in node.children()
+    return
+
+  hasVisited: (node) ->
+    node.__visitors = [] if !node.hasOwnProperty('__visitors')
+    return node.__visitors.indexOf(this) != -1
+
+  finish: ->
+    for node in @visitedNodes
+      visitors = node.__visitors
+      index = visitors.indexOf(this)
+      if index == -1 then throw 'visitor list inconsistency'
+      visitors.splice(index, 1)
+    return


### PR DESCRIPTION
Per #44, this PR adds a method to find "unnecessary nodes". It does not yet do anything with them.

It's fun to play with: if you clear out `localStorage`, restart Apparatus, and run this in the console, it returns an empty array. If you add some shapes to your drawing, it still returns an empty array. But if you delete some shapes, it will return their bits, reporting them as uncollected garbage. Even if you press "New", the garbage will still stick around.

We probably want to do something about this. We can make the deletion methods more intelligent about identifying when something is no longer in use and can be removed entirely. OR we can just regularly find and remove unnecessary nodes as a pre-serialization GC thing, using this method. I am partial to this latter approach, since it means we don't need to be careful to avoid leaks at every turn – we can just detect them in one fell swoop.

Please let me know what you think, @electronicwhisper.

🎄🎄🎄🎄🎄🎄🎄
