### PR TITLE
Make Serializer less stack-hungry

### DIFF
--- a/src/Storage/Serializer.coffee
+++ b/src/Storage/Serializer.coffee
@@ -23,6 +23,7 @@ module.exports = class Serializer
 
   jsonify: (rootValue) ->
     objects = {} # id : json
+    objectsToJsonify = []
 
     jsonifyValue = (value) =>
       if _.isArray(value)
@@ -41,7 +42,7 @@ module.exports = class Serializer
         # We'll need to jsonify the object and add it to objects. First, set a
         # placeholder value so recursive references work.
         objects[id] = "PROCESSING"
-        objects[id] = jsonifyObject(object)
+        objectsToJsonify.push(object)
       return {__ref: id}
 
     jsonifyObject = (object) =>
@@ -57,6 +58,9 @@ module.exports = class Serializer
       return result
 
     root = jsonifyValue(rootValue)
+    while objectsToJsonify.length > 0
+      nextObject = objectsToJsonify.pop()
+      objects[Util.getId(nextObject)] = jsonifyObject(nextObject)
     return {objects, root}
 
 


### PR DESCRIPTION
The serializer is currently limited by the JS stack, since it's so gosh-darn recursive. This change "trampolines" calls to `jsonifyObject` so that much larger diagrams can be serialized.
