### PR TITLE
Changed Node constructor to make it easier to override

### DIFF
--- a/src/Model/Node.coffee
+++ b/src/Model/Node.coffee
@@ -76,14 +76,11 @@ _ = require "underscore"
 module.exports = Node = {
   label: "Node"
 
-  constructor: ->
-    @_master = null
+  constructor: (@_master, @_head) ->
     @_variants = []
 
     @_parent = null
     @_children = []
-
-    @_head = null
 
     @_isHatched = false
 
@@ -207,13 +204,10 @@ module.exports = Node = {
   _createVariantWithHead: (head=null, spec) ->
     variant = Object.create(this)
     _.extend(variant, spec) if spec?
-    variant.constructor()
 
-    if !head?
-      head = variant
+    head ?= variant
+    variant.constructor(this, head)
 
-    variant._head = head
-    variant._master = this
     @_variants.push(variant)
 
     return variant
@@ -309,4 +303,4 @@ module.exports = Node = {
     return lineage
 }
 
-Node.constructor()
+Node.constructor(null, null)


### PR DESCRIPTION
Currently, `Node._createVariantWithHead` sets the master and head of the new variant after it calls `Node.constructor`. But this causes problems since overridden constructors won't have access to master and head.
