### PR TITLE
add rendering context

### DIFF
--- a/src/Model/Model.coffee
+++ b/src/Model/Model.coffee
@@ -109,21 +109,56 @@ Model.Stroke.addChildren [
 # Elements
 # =============================================================================
 
+# Shape Interpretation Contexts
+RENDERING = 'renderingContext'
+ANCHOR_COLLECTION = 'anchorCollectionContext'
+NONE = 'noDraggingContext'
+
 Model.Shape = Model.Element.createVariant
   label: "Shape"
+
+  getAllowedShapeInterpretationContext: () ->
+    return [RENDERING]
+
+  getAllowedShapeInterpretationContextForChildren: () ->
+    return [RENDERING]
 
 Model.Shape.addChildren [
   Model.Transform.createVariant()
 ]
 
-
 Model.Group = Model.Shape.createVariant
   label: "Group"
+  getAllowedShapeInterpretationContext: () ->
+    childElements = this.childElements()
+    isRenderable = _.some(childElements, (child) ->
+      _.some(child.getAllowedShapeInterpretationContext(), (shapeContext) -> shapeContext == RENDERING))
+
+    if childElements.length == 0
+      return [ANCHOR_COLLECTION, RENDERING]
+    else if isRenderable
+      return [RENDERING]
+    else
+      return [ANCHOR_COLLECTION]
+
+  getAllowedShapeInterpretationContextForChildren: () ->
+    if this._parent?.getAllowedShapeInterpretationContextForChildren
+      return this._parent.getAllowedShapeInterpretationContextForChildren()
+    else
+      return [RENDERING]
+
   graphicClass: Graphic.Group
 
 
 Model.Anchor = Model.Shape.createVariant
   label: "Anchor"
+
+  getAllowedShapeInterpretationContext: () ->
+    return [ANCHOR_COLLECTION]
+
+  getAllowedShapeInterpretationContextForChildren: () ->
+    return [NONE]
+
   graphicClass: Graphic.Anchor
 
 createAnchor = (x, y) ->
@@ -157,11 +192,16 @@ Model.Path.addChildren [
 
 Model.Circle = Model.Path.createVariant
   label: "Circle"
+  getAllowedShapeInterpretationContextForChildren: () ->
+    return [NONE]
+  
   graphicClass: Graphic.Circle
 
 
 Model.Rectangle = Model.Path.createVariant
   label: "Rectangle"
+  getAllowedShapeInterpretationContextForChildren: () ->
+    return [ANCHOR_COLLECTION]
 
 Model.Rectangle.addChildren [
   createAnchor("0.00", "0.00")
@@ -174,6 +214,9 @@ Model.Rectangle.addChildren [
 Model.TextComponent = Model.Component.createVariant
   _devLabel: "TextComponent"
   label: "Text"
+  getAllowedShapeInterpretationContextForChildren: () ->
+    return [NONE]
+
   graphicClass: Graphic.TextComponent
 
 Model.TextComponent.addChildren [

--- a/src/View/Outline.coffee
+++ b/src/View/Outline.coffee
@@ -66,7 +66,8 @@ R.create "OutlineChildren",
 
   render: ->
     {element} = @props
-    R.div {className: "OutlineChildren"},
+    interpretationClasses = element.getAllowedShapeInterpretationContextForChildren().join(" ")
+    R.div {className: "OutlineChildren " + interpretationClasses},
       for childElement in element.childElements()
         R.OutlineTree {element: childElement, key: Util.getId(childElement)}
 
@@ -204,6 +205,7 @@ R.create "OutlineItem",
   # then insert at the end). If nothing is close enough, it will return null.
   _findDropSpot: (drag) ->
     {x, y, outlineEl} = drag
+    {element} = @props
     dragPosition = [x, y]
 
     # Temporarily hide OutlinePlaceholder for the purpose of this calculation.
@@ -219,8 +221,11 @@ R.create "OutlineItem",
       if quadrance < bestDropSpot.quadrance
         bestDropSpot = {quadrance, outlineChildrenEl, beforeOutlineTreeEl}
 
+    allowedDraggingClasses = element.getAllowedShapeInterpretationContext().map((interpretationContext) -> 
+      ".OutlineChildren." + interpretationContext).join(", ")
+
     # All the places within which we could drop.
-    outlineChildrenEls = outlineEl.querySelectorAll(".OutlineChildren")
+    outlineChildrenEls = outlineEl.querySelectorAll(allowedDraggingClasses)
 
     for outlineChildrenEl in outlineChildrenEls
       # Don't try to insert it into itself!


### PR DESCRIPTION
This pr adds contexts that specify where elements can be dragged and what types of elements are allowed as children of an element. The changes are meant to fix https://github.com/cdglabs/apparatus/issues/54. 

getAllowedDragContext determines what context the element can be dragged into.
getChildDragContext determined what context an element must have to be dragged into its children.

The properties are obtained using a getter because for groups it depends on the contents of the group.
One possible issue with this is for groups to determine their rendering context there is a recursive call that may be expensive for deeply nested groups.
