### PR TITLE
add double click to end scrubbing

### DIFF
--- a/src/View/ExpressionCode.coffee
+++ b/src/View/ExpressionCode.coffee
@@ -66,6 +66,7 @@ R.create "ExpressionCode",
 
     @mirror.on("change", @_onChange)
     @mirror.on("mousedown", @_onMirrorMouseDown)
+    @mirror.on("dblclick", @_onMirrorDoubleClick)
     @componentDidUpdate()
 
   componentDidUpdate: ->
@@ -81,6 +82,12 @@ R.create "ExpressionCode",
     if Util.matches(el, ".cm-number")
       mouseDownEvent.preventDefault()
       @_startNumberScrub(mouseDownEvent)
+
+  _onMirrorDoubleClick: (mirror, dblClickEvent) ->
+    el = dblClickEvent.target
+    if Util.matches(el, ".cm-number")
+      dblClickEvent.preventDefault()
+      @_endNumberScrub(dblClickEvent) 
 
   _onMouseUp: (mouseUpEvent) ->
     {attribute} = @props
@@ -334,6 +341,10 @@ R.create "ExpressionCode",
     @mirror.focus()
     @mirror.setSelection(start, end)
     @_startScrubbingSelection(mouseDownEvent)
+
+  _endNumberScrub: (dblClickEvent) ->
+    position = @mirror.coordsChar({left: dblClickEvent.clientX, top: dblClickEvent.clientY})
+    @mirror.setCursor(position)
 
   _getTokenPositionFromCursor: (mouseDownEvent) ->
     position = @mirror.coordsChar({left: mouseDownEvent.clientX, top: mouseDownEvent.clientY})


### PR DESCRIPTION
This pr adds a double click event that ends the scrubbing behavior and sets the cursor inside the number being clicked on. Right now there is no way to click inside a number expression that is being scrubbed. The only way to edit it is to click around it and then use the arrow keys to edit it.

![mngxnztokg](https://cloud.githubusercontent.com/assets/3388704/15599428/03f29e72-2398-11e6-887e-95002c22bd05.gif)
